### PR TITLE
fix: yarn install command version differences

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -83,4 +83,6 @@ runs:
     - name: install dependencies
       shell: bash
       run: |
-        yarn install --frozen-lockfile --no-progress --non-interactive
+        [ "$(expr "$(yarn -v)" \< '2')" = 1 ] && 
+          yarn install --frozen-lockfile --no-progress --non-interactive || 
+          yarn install --immutable


### PR DESCRIPTION
This updates the `yarn install` command to support both Yarn 1 and Yarn 2+ — as they differ in their accepted options.
```sh
[ "$(expr "$(yarn -v)" \< '2')" = 1 ] && 
  yarn install --frozen-lockfile --no-progress --non-interactive || 
  yarn install --immutable
```
The new script does a lexicographic comparison — and is good until Yarn 10 😅