### PR TITLE
chore: move off deprecated set-output syntax

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -48,7 +48,7 @@ runs:
           NODE_VERSION="16"
         fi
 
-        echo "::set-output name=node-version::${NODE_VERSION}"
+        echo "node-version=${NODE_VERSION}" >> $GITHUB_OUTPUT
 
     - uses: actions/setup-node@v2
       with:
@@ -59,7 +59,7 @@ runs:
       id: yarn-cache-dir-path
       shell: bash
       run: |
-        echo "::set-output name=dir::$(yarn cache dir)"
+        echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
     - uses: actions/cache@v2
       with:


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

currently run logs are littered with this:
![Screenshot 2023-01-31 at 10 21 08 AM](https://user-images.githubusercontent.com/333260/215848810-430449b9-cfa4-42f5-abb4-d471c79f25db.png)
